### PR TITLE
Help documentation only for GUI mode

### DIFF
--- a/builder.sce
+++ b/builder.sce
@@ -32,7 +32,11 @@ toolbox_dir = get_absolute_file_path("builder.sce");
 
 tbx_builder_macros(toolbox_dir);
 tbx_builder_gateway(toolbox_dir);
-tbx_builder_help(toolbox_dir);
+
+if getscilabmode()=="STD" then
+	tbx_builder_help(toolbox_dir);
+end
+
 tbx_build_loader(TOOLBOX_NAME, toolbox_dir);
 tbx_build_cleaner(TOOLBOX_NAME, toolbox_dir);
 


### PR DESCRIPTION
Help documentation fails to build in cli-mode as the documentation are based on Java features which are not available in the mode. Rectified by making it available only for GUI mode.
