### PR TITLE
Corrected LaTeX markup, examples in various help files and options indices in 'fot_lsqnonlin'

### DIFF
--- a/help/en_US/fot_fgoalattain.xml
+++ b/help/en_US/fot_fgoalattain.xml
@@ -499,7 +499,7 @@ b=[2;1;1];
 //We specify the linear equality constraints below.
 Aeq = [1/3,-5; 2, 1];
 beq =  [11;8];
-// Run fminimax
+// Run fot_fgoalattain
 [x,fval,maxfval,exitflag,output,lambda] = fot_fgoalattain(gattainObjfun,x0,goal,weight,A,b,Aeq,beq)
 
 

--- a/help/en_US/fot_fminimax.xml
+++ b/help/en_US/fot_fminimax.xml
@@ -438,7 +438,7 @@ c=[x(1)^2-1,x(1)^2+x(2)^2-1];
 ceq=[];
 endfunction
 // Run fot_fminimax
-[x,fval,maxfval,exitflag,output,lambda] = fot_fminimax(myfun, x0,A,b,Aeq,beq,lb,ub)
+[x,fval,maxfval,exitflag,output,lambda] = fot_fminimax(myfun, x0,A,b,Aeq,beq,lb,ub,nlc)
 
 
    ]]></programlisting>

--- a/help/en_US/fot_intquadprog.xml
+++ b/help/en_US/fot_intquadprog.xml
@@ -377,6 +377,7 @@ F &amp;=
 </para>
    <programlisting role="example"><![CDATA[
 //Example 7:
+//Currently, this CRASHES Scilab because of a segmentation fault error
 //Minimize 0.5*x'*H*x + f'*x with
 f=[1; 2; 3; 4; 5; 6]; H=eye(6,6); H(1,1) = -1;
 //Inequality constraints

--- a/help/en_US/fot_intquadprog.xml
+++ b/help/en_US/fot_intquadprog.xml
@@ -140,7 +140,7 @@ Find x in R^6 such that it minimizes:
    <para>
 <latex>
 \begin{eqnarray}
-\mbox{min}_{x}\ f(x) &amp;= \dfrac{1}{2}x'\boldsymbol{\cdot} H\boldsymbol{\cdot}x + f' \boldsymbol{\cdot}  x\\
+\mbox{min}_{x}\ f(x) &amp;= \dfrac{1}{2}x^T \boldsymbol{\cdot} H\boldsymbol{\cdot}x + f^T \boldsymbol{\cdot}  x\\
 \text{Where: } H &amp;= I_{6}\\
 F &amp;=
 \begin{array}{cccccc}
@@ -224,7 +224,7 @@ A= [0,1,0,1,2,-1;
 b = [-1; 2.5];
 //Equality constraints
 Aeq= [1,-1,1,0,3,1;
--1,0,-3,-4,5,6;
+-1,0,2,1,1,0;
 2,5,3,0,1,0];
 beq=[1; 2; 3];
 //Integer Constraints
@@ -264,7 +264,7 @@ A= [0,1,0,1,2,-1;
 b = [-1; 2.5];
 //Equality constraints
 Aeq= [1,-1,1,0,3,1;
--1,0,-3,-4,5,6;
+-1,0,2,1,1,0;
 2,5,3,0,1,0];
 beq=[1; 2; 3];
 //Variable bounds
@@ -292,7 +292,7 @@ A= [0,1,0,1,2,-1;
 b = [-1; 2.5];
 //Equality constraints
 Aeq= [1,-1,1,0,3,1;
--1,0,-3,-4,5,6;
+-1,0,2,1,1,0;
 2,5,3,0,1,0];
 beq=[1; 2; 3];
 //Variable bounds
@@ -334,14 +334,13 @@ Infeasible Problems: Find x in R^6 such that it minimizes the objective function
 //Currently, this crashes Scilab because of a segfault error.
 //Minimize 0.5*x'*H*x + f'*x with
 f=[1; 2; 3; 4; 5; 6]; H=eye(6,6);
-f=[1; 2; 3; 4; 5; 6]; H=eye(6,6);
 //Inequality constraints
 A= [0,1,0,1,2,-1;
 -1,0,2,1,1,0];
 b = [-1; 2.5];
 //Equality constraints
 Aeq= [0,1,0,1,2,-1;
--1,0,-3,-4,5,6];
+-1,0,2,1,1,0];
 beq=[4; 2];
 //Integer Constraints
 intcon = [2 ,4];
@@ -358,7 +357,7 @@ Unbounded Problems: Find x in R^6 such that it minimizes the objective function 
 <para>
 <latex>
 \begin{eqnarray}
-\mbox{min}_{x}\ f(x) &amp;= \dfrac{1}{2}x'\boldsymbol{\cdot} H\boldsymbol{\cdot}x + f' \boldsymbol{\cdot}  x\\
+\mbox{min}_{x}\ f(x) &amp;= \dfrac{1}{2}x^T \boldsymbol{\cdot} H\boldsymbol{\cdot}x + f^T \boldsymbol{\cdot}  x\\
 \text{Where H is specified below and} \\
 F &amp;=
 \begin{array}{cccccc}
@@ -386,7 +385,7 @@ A= [0,1,0,1,2,-1;
 b = [-1; 2.5];
 //Equality constraints
 Aeq= [1,-1,1,0,3,1;
--1,0,-3,-4,5,6];
+-1,0,2,1,1,0];
 beq=[1; 2];
 intcon = [2 ,4];
 //Running fot_intquadprog

--- a/help/en_US/fot_linprog.xml
+++ b/help/en_US/fot_linprog.xml
@@ -260,7 +260,7 @@ Primal Infeasible Problems: Find x in R^3 such that it minimizes:
    <para>
 <latex>
 \begin{eqnarray}
-mbox{min}_{x}\ f(x) = x_{1} - x_{2}  \- x_{3}\\
+\mbox{min}_{x}\ f(x) = x_{1} - x_{2}  \- x_{3}\\
 \end{eqnarray}
 \\\text{Subjected to:}\\
 \begin{eqnarray}
@@ -301,7 +301,7 @@ Unbounded Problems: Find x in R^3 such that it minimizes:
    <para>
 <latex>
 \begin{eqnarray}
-mbox{min}_{x}\ f(x) = x_{1} - x_{2}  \- x_{3}\\
+\mbox{min}_{x}\ f(x) = x_{1} - x_{2}  \- x_{3}\\
 \end{eqnarray}
 \\\text{Subjected to:}\\
 \begin{eqnarray}

--- a/help/en_US/fot_quadprogCLP.xml
+++ b/help/en_US/fot_quadprogCLP.xml
@@ -191,7 +191,7 @@ f=[1; 2; 3; 4; 5; 6]; H=eye(6,6);
 f = [-1;-1];
 A = [1,2;2,1];
 b = [3;3];
-[xopt,fopt] = fot_quadprogCLP([],f,A,b);
+[xopt,fopt] = fot_quadprogCLP([],f,A,b)
    ]]></programlisting>
 </refsection>
 

--- a/help/en_US/fot_quadprogmat.xml
+++ b/help/en_US/fot_quadprogmat.xml
@@ -165,7 +165,7 @@ Find x in R^6 such that it minimizes:
    <para>
 <latex>
 \begin{eqnarray}
-\mbox{min}_{x}\ f(x) &amp;= \dfrac{1}{2}x'\boldsymbol{\cdot} H\boldsymbol{\cdot}x + f' \boldsymbol{\cdot}  x\\
+\mbox{min}_{x}\ f(x) &amp;= \dfrac{1}{2}x^T \boldsymbol{\cdot} H\boldsymbol{\cdot}x + f^T \boldsymbol{\cdot}  x\\
 \text{Where: } H &amp;= I_{6}\\
 F &amp;=
 \begin{array}{cccccc}
@@ -237,7 +237,7 @@ A= [0,1,0,1,2,-1;
 b = [-1; 2.5];
 //Equality constraints
 Aeq= [1,-1,1,0,3,1;
--1,0,-3,-4,5,6;
+-1,0,2,1,1,0;
 2,5,3,0,1,0];
 beq=[1; 2; 3];
 [xopt,fopt,exitflag,output,lambda]=fot_quadprogmat(H,f,A,b,Aeq,beq)
@@ -274,7 +274,7 @@ A= [0,1,0,1,2,-1;
 b = [-1; 2.5];
 //Equality constraints
 Aeq= [1,-1,1,0,3,1;
--1,0,-3,-4,5,6;
+-1,0,2,1,1,0;
 2,5,3,0,1,0];
 beq=[1; 2; 3];
 //Variable bounds
@@ -301,7 +301,7 @@ A= [0,1,0,1,2,-1;
 b = [-1; 2.5];
 //Equality constraints
 Aeq= [1,-1,1,0,3,1;
--1,0,-3,-4,5,6;
+-1,0,2,1,1,0;
 2,5,3,0,1,0];
 beq=[1; 2; 3];
 //Variable bounds
@@ -339,7 +339,7 @@ A= [0,1,0,1,2,-1;
 b = [-1; 2.5];
 //Equality constraints
 Aeq= [0,1,0,1,2,-1;
--1,0,-3,-4,5,6];
+-1,0,2,1,1,0];
 beq=[4; 2];
 [xopt,fopt,exitflag,output,lambda]=fot_quadprogmat(H,f,A,b,Aeq,beq)
 ]]></programlisting>
@@ -353,7 +353,7 @@ Unbounded Problems: Find x in R^6 such that it minimizes the objective function 
 <para>
 <latex>
 \begin{eqnarray}
-\mbox{min}_{x}\ f(x) &amp;= \dfrac{1}{2}x'\boldsymbol{\cdot} H\boldsymbol{\cdot}x + f' \boldsymbol{\cdot}  x\\
+\mbox{min}_{x}\ f(x) &amp;= \dfrac{1}{2}x^T \boldsymbol{\cdot} H\boldsymbol{\cdot}x + f^T \boldsymbol{\cdot}  x\\
 \text{Where H is specified below and}\\
 F &amp;=
 \begin{array}{cccccc}
@@ -381,7 +381,7 @@ A= [0,1,0,1,2,-1;
 b = [-1; 2.5];
 //Equality constraints
 Aeq= [1,-1,1,0,3,1;
--1,0,-3,-4,5,6];
+-1,0,2,1,1,0];
 beq=[1; 2];
 [xopt,fopt,exitflag,output,lambda]=fot_quadprogmat(H,f,A,b,Aeq,beq)
 ]]></programlisting>

--- a/macros/fot_lsqnonlin.sci
+++ b/macros/fot_lsqnonlin.sci
@@ -201,7 +201,7 @@ function [xopt,resnorm,residual,exitflag,output,lambda,gradient] = fot_lsqnonlin
 		error(errmsg);
 	end
 
-	options = struct(	"MaxIter"   , [3000], "CpuTime"   , [600], "GradObj"	, ["off"]);
+	options = struct(	"MaxIter"   , [3000], "CpuTime"   , [600], "GradObj"	, "off");
 
 	for i = 1:(size(param))/2
 
@@ -286,7 +286,7 @@ function [xopt,resnorm,residual,exitflag,output,lambda,gradient] = fot_lsqnonlin
 		y = sum(yVal.^2);
 	endfunction
 
-	if (options(6) == "on")
+	if (options("GradObj") == "on")
         ierr = execstr('[initx initdx]=_fun(x0)', "errcatch")
         if ierr <> 0 then
         lamsg = lasterror();
@@ -307,7 +307,7 @@ function [xopt,resnorm,residual,exitflag,output,lambda,gradient] = fot_lsqnonlin
 		endfunction
 	end
 	
-    options(6) = __fGrad;
+    options("GradObj") = __fGrad;
 	
     function [c, ceq] = nlc(x)
         c = [];


### PR DESCRIPTION
The changes that have been made are as follows:

- The LaTeX rendering in **fot_intquadprog** and **fot_quadprogmat** was incorrect due to 'single quote' used in _eqnarray_ environment. It has been replaced by superscript T to denote transpose of the respective matrices.
- The examples 3 to 7 in  **fot_intquadprog** and **fot_quadprogmat**  have been corrected
- The indices in **fot_lsqnonlin** have been corrected to refer to options as a struct rather than a list
- LaTeX markup errors have been removed in **fot_linprog.xml**
- Example 5 in **fot_fminimax** has been corrected to pass non linear constraints
- Minor changes have been made to examples in **fot_fgoalattain.xml** and **fot_quadprogCLP.xml**